### PR TITLE
Webpack browser build

### DIFF
--- a/no-crypto.js
+++ b/no-crypto.js
@@ -1,0 +1,2 @@
+// throw an error when attempting to load 'crypto'
+throw new Error('\'crypto\' module not supported');

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "module": "lib/main.js",
   "dependencies": {
     "@stablelib/ed25519": "^1.0.1",
-    "@stablelib/random": "^1.0.0",
     "base58-universal": "^1.0.0",
     "crypto-ld": "^4.0.2",
     "esm": "^3.2.25"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "eslint": "^7.9.0",
     "eslint-config-digitalbazaar": "^2.0.0",
     "eslint-plugin-jsdoc": "^30.7.8",
-    "karma": "^4.0.1",
+    "karma": "^5.2.3",
     "karma-babel-preprocessor": "^8.0.0",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^3.1.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,21 @@
+const path = require('path');
+
+module.exports = {
+  mode: 'production',
+  target: 'web',
+  externals: ['node-forge'],
+  output: {
+    path: path.join(__dirname, 'dist'),
+    filename: '[name].min.js',
+    library: '[name]',
+    libraryTarget: 'umd'
+  },
+  node: false,
+  resolve: {
+    alias: {
+      // throw an error if trying to import 'crypto'
+      // workaround for "node" feature not working in sub-dependencies
+      crypto$: path.resolve(__dirname, 'no-crypto.js')
+    }
+  }
+};


### PR DESCRIPTION
This gets the build product down to 33kb


```
[liminal18@nixos:~/Programs/nodeJS/digital_bazaar/ed25519-verification-key-2020]$ npx webpack .
[webpack-cli] Compilation finished
Hash: 78dbe9f71aefe2edae6c
Version: webpack 4.44.2
Time: 2162ms
Built at: 12/07/2020 5:27:48 PM
      Asset      Size  Chunks             Chunk Names
main.min.js  32.3 KiB       0  [emitted]  main
Entrypoint main = main.min.js
 [0] ./node_modules/@stablelib/wipe/lib/wipe.js 1.12 KiB {0} [built]
 [1] ./node_modules/@stablelib/ed25519/lib/ed25519.js 19.8 KiB {0} [built]
 [2] ./node_modules/@stablelib/binary/lib/binary.js 15.2 KiB {0} [built]
 [3] ./node_modules/crypto-ld/lib/LDKeyPair.js 4.52 KiB {0} [built]
 [4] ./node_modules/crypto-ld/lib/index.js 305 bytes {0} [built]
 [5] multi . 28 bytes {0} [built]
 [6] ./node_modules/@stablelib/random/lib/random.js 3.1 KiB {0} [built]
 [7] ./node_modules/@stablelib/random/lib/source/system.js 1.23 KiB {0} [built]
 [8] ./node_modules/@stablelib/random/lib/source/browser.js 1.21 KiB {0} [built]
 [9] ./node_modules/@stablelib/random/lib/source/node.js 1.53 KiB {0} [built]
[11] ./node_modules/@stablelib/int/lib/int.js 1.69 KiB {0} [built]
[12] ./node_modules/@stablelib/sha512/lib/sha512.js 18.4 KiB {0} [built]
[13] ./node_modules/crypto-ld/lib/CryptoLD.js 2.06 KiB {0} [built]
[14] ./node_modules/crypto-ld/lib/LDVerifierKeyPair.js 1.32 KiB {0} [built]
[15] ./lib/main.js + 4 modules 12.7 KiB {0} [built]
     | ./lib/main.js 148 bytes [built]
     | ./lib/Ed25519VerificationKey2020.js 7.39 KiB [built]
     | ./node_modules/base58-universal/main.js 441 bytes [built]
     | ./lib/ed25519-browser.js 517 bytes [built]
     | ./node_modules/base58-universal/baseN.js 4.27 KiB [built]
    + 1 hidden module

```

note: this build will throw in node.