### PR TITLE
Update to crypto-ld v5, add backwards compat with 2018 key types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # @digitalbazaar/ed25519-verification-key-2020 ChangeLog
 
-## 1.1.0 -
+## 2.0.0 -
 
 ## Changed
-- Update to use `crypto-ld v5.0`. No public API changes from the previous v4 dep.
+- Update to use `crypto-ld v5.0`.
+- **BREAKING**: Removed helper methods `addPublicKey` and `addPrivateKey`.
 
 ## Added
 - Add `Ed25519VerificationKey2020.fromEd25519VerificationKey2018()` method,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @digitalbazaar/ed25519-verification-key-2020 ChangeLog
 
+## 1.1.0 -
+
+## Changed
+- Update to use `crypto-ld v5.0`. No public API changes from the previous v4 dep.
+
+## Added
+- Add `Ed25519VerificationKey2020.fromEd25519VerificationKey2018()` method,
+  for backwards compatibility with the `Ed25519VerificationKey2018` key type.
+  See "Converting from previous Ed25519VerificationKey2018 key type" section
+  of the README for details.
+
 ## 1.0.0 - 2021-02-27
 
 Initial version.

--- a/README.md
+++ b/README.md
@@ -151,6 +151,51 @@ const valid = await verify({data, signature});
 // true
 ```
 
+### Converting from previous Ed25519VerificationKey2018 key type
+
+If you have serialized and stored keys of the previous 
+`Ed25519VerificationKey2018` key type (for example, generated using
+the [`ed25519-verification-key-2018`](https://github.com/digitalbazaar/ed25519-verification-key-2018))
+library, or using the `Ed25519KeyPair` keys bundled with `crypto-ld v3.x`),
+things to keep in mind:
+
+* Instances of those key types still contain the same key material, the only
+  thing that has changed from the 2018 suite to the 2020 is the way the public
+  and private key material is serialized, when exporting. The 2018 suite key 
+  types serialize using the `publicKeyBase58` and `privateKeyBase58` properties,
+  and the 2020 suite key (this repo) serializes using corresponding
+  `publicKeyMultibase` and `privateKeyMultibase` property.
+* You can convert from the 2018 key type to the 2020 using the provided
+  `Ed25519VerificationKey2020.fromEd25519VerificationKey2018()` method (see below).
+* They `generate()` the same key material, given the same `seed` parameter.
+* Both the 2018 and 2020 keys produce and verify the same signatures.
+
+Example of converting:
+
+```js
+import {Ed25519VerificationKey2018}
+  from '@digitalbazaar/ed25519-verification-key-2018';
+import {Ed25519VerificationKey2020}
+  from '@digitalbazaar/ed25519-verification-key-2020';
+
+const keyPair2018 = await Ed25519VerificationKey2018.generate({
+  controller: 'did:example:1234'
+});
+
+const keyPair2020 = await Ed25519VerificationKey2020
+  .fromEd25519VerificationKey2018({keyPair: keyPair2018});
+
+// The resulting keyPair2020 will have the same `id` and `controller` properties
+// as its 2018 source. They will also produce and verify the same signatures.
+
+const data = (new TextEncoder()).encode('test data goes here');
+const signatureBytes2018 = await keyPair2018.signer().sign({data});
+
+// this is the same signature as that produced by the 2020 key. And will verify
+// the same.
+await keyPair2020.verifier().verify({data, signature: signatureBytes2018})
+// true
+```
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -160,12 +160,12 @@ library, or using the `Ed25519KeyPair` keys bundled with `crypto-ld v3.x`),
 things to keep in mind:
 
 * Instances of those key types still contain the same key material, the only
-  thing that has changed from the 2018 suite to the 2020 is the way the public
-  and private key material is serialized, when exporting. The 2018 suite key 
+  thing that has changed from the 2018 suite to the 2020 suite is the way the public
+  and private key material is serialized when exporting. The 2018 suite key 
   types serialize using the `publicKeyBase58` and `privateKeyBase58` properties,
   and the 2020 suite key (this repo) serializes using corresponding
   `publicKeyMultibase` and `privateKeyMultibase` property.
-* You can convert from the 2018 key type to the 2020 using the provided
+* You can convert from the 2018 key type to the 2020 key type using the provided
   `Ed25519VerificationKey2020.fromEd25519VerificationKey2018()` method (see below).
 * They `generate()` the same key material, given the same `seed` parameter.
 * Both the 2018 and 2020 keys produce and verify the same signatures.

--- a/lib/Ed25519VerificationKey2020.js
+++ b/lib/Ed25519VerificationKey2020.js
@@ -54,6 +54,30 @@ export class Ed25519VerificationKey2020 extends LDKeyPair {
   }
 
   /**
+   * Instance creation method for backwards compatibility with the
+   * `Ed25519VerificationKey2018` key suite.
+   *
+   * @see https://github.com/digitalbazaar/ed25519-verification-key-2018
+   *
+   * @param {Ed25519VerificationKey2018} keyPair - Ed25519 2018 suite key pair.
+   *
+   * @returns {Ed25519VerificationKey2020} - 2020 suite instance.
+   */
+  static fromEd25519VerificationKey2018({keyPair}) {
+    const keyPair2020 = new Ed25519VerificationKey2020({
+      id: keyPair.id,
+      controller: keyPair.controller,
+      publicKeyMultibase: `z${keyPair.publicKeyBase58}`
+    });
+
+    if(keyPair.privateKeyBase58) {
+      keyPair2020.privateKeyMultibase = `z${keyPair.privateKeyBase58}`;
+    }
+
+    return keyPair2020;
+  }
+
+  /**
    * Generates a KeyPair with an optional deterministic seed.
    *
    * @param {object} [options={}] - Options hashmap.

--- a/lib/Ed25519VerificationKey2020.js
+++ b/lib/Ed25519VerificationKey2020.js
@@ -63,7 +63,7 @@ export class Ed25519VerificationKey2020 extends LDKeyPair {
    *
    * @returns {Ed25519VerificationKey2020} - 2020 suite instance.
    */
-  static fromEd25519VerificationKey2018({keyPair}) {
+  static fromEd25519VerificationKey2018({keyPair} = {}) {
     const keyPair2020 = new Ed25519VerificationKey2020({
       id: keyPair.id,
       controller: keyPair.controller,

--- a/lib/Ed25519VerificationKey2020.js
+++ b/lib/Ed25519VerificationKey2020.js
@@ -1,13 +1,13 @@
 /*!
- * Copyright (c) 2020 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2021 Digital Bazaar, Inc. All rights reserved.
  */
 import * as base58btc from 'base58-universal';
 import ed25519 from './ed25519.js';
-import {LDVerifierKeyPair} from 'crypto-ld';
+import {LDKeyPair} from 'crypto-ld';
 
 const SUITE_ID = 'Ed25519VerificationKey2020';
 
-export class Ed25519VerificationKey2020 extends LDVerifierKeyPair {
+export class Ed25519VerificationKey2020 extends LDKeyPair {
   /**
    * An implementation of the Ed25519VerificationKey2020 spec, for use with
    * Linked Data Proofs.
@@ -137,29 +137,25 @@ export class Ed25519VerificationKey2020 extends LDVerifierKeyPair {
   }
 
   /**
-   * Adds a public key base to the key pair object.
+   * Exports the serialized representation of the KeyPair
+   * and other information that json-ld Signatures can use to form a proof.
    *
-   * @param {object} options - Options hashmap.
-   * @param {object} options.key - Key pair object being exported.
+   * @param {object} [options={}] - Options hashmap.
+   * @param {boolean} [options.publicKey] - Export public key material?
+   * @param {boolean} [options.privateKey] - Export private key material?
    *
-   * @returns {object} A PublicKeyNode, with key material.
+   * @returns {object} A public key object
+   *   information used in verification methods by signatures.
    */
-  addPublicKey({key}) {
-    key.publicKeyMultibase = this.publicKeyMultibase;
-    return key;
-  }
-
-  /**
-   * Adds the private key material to the key pair object.
-   *
-   * @param {object} options - Options hashmap.
-   * @param {object} options.key - Key pair object being exported.
-   *
-   * @returns {object} The keyNode with encoded private key material.
-   */
-  addPrivateKey({key}) {
-    key.privateKeyMultibase = this.privateKeyMultibase;
-    return key;
+  export({publicKey = false, privateKey = false}) {
+    const exportedKey = super.export({publicKey, privateKey});
+    if(publicKey) {
+      exportedKey.publicKeyMultibase = this.publicKeyMultibase;
+    }
+    if(privateKey) {
+      exportedKey.privateKeyMultibase = this.privateKeyMultibase;
+    }
+    return exportedKey;
   }
 
   /**

--- a/lib/Ed25519VerificationKey2020.js
+++ b/lib/Ed25519VerificationKey2020.js
@@ -168,8 +168,8 @@ export class Ed25519VerificationKey2020 extends LDKeyPair {
    * @param {boolean} [options.publicKey] - Export public key material?
    * @param {boolean} [options.privateKey] - Export private key material?
    *
-   * @returns {object} A public key object
-   *   information used in verification methods by signatures.
+   * @returns {object} A plain js object that's ready for serialization
+   *   (to JSON, etc), for use in DIDs, Linked Data Proofs, etc.
    */
   export({publicKey = false, privateKey = false} = {}) {
     if(!(publicKey || privateKey)) {

--- a/lib/Ed25519VerificationKey2020.js
+++ b/lib/Ed25519VerificationKey2020.js
@@ -147,8 +147,16 @@ export class Ed25519VerificationKey2020 extends LDKeyPair {
    * @returns {object} A public key object
    *   information used in verification methods by signatures.
    */
-  export({publicKey = false, privateKey = false}) {
-    const exportedKey = super.export({publicKey, privateKey});
+  export({publicKey = false, privateKey = false} = {}) {
+    if(!(publicKey || privateKey)) {
+      throw new TypeError(
+        'Export requires specifying either "publicKey" or "privateKey".');
+    }
+    const exportedKey = {
+      id: this.id,
+      type: this.type,
+      controller: this.controller
+    };
     if(publicKey) {
       exportedKey.publicKeyMultibase = this.publicKeyMultibase;
     }

--- a/lib/Ed25519VerificationKey2020.js
+++ b/lib/Ed25519VerificationKey2020.js
@@ -58,7 +58,7 @@ export class Ed25519VerificationKey2020 extends LDKeyPair {
    * `Ed25519VerificationKey2018` key suite.
    *
    * @see https://github.com/digitalbazaar/ed25519-verification-key-2018
-   *
+   * @typedef {object} Ed25519VerificationKey2018
    * @param {Ed25519VerificationKey2018} keyPair - Ed25519 2018 suite key pair.
    *
    * @returns {Ed25519VerificationKey2020} - 2020 suite instance.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@stablelib/ed25519": "^1.0.1",
     "base58-universal": "^1.0.0",
-    "crypto-ld": "^4.0.2",
+    "crypto-ld": "^5.0.0",
     "esm": "^3.2.25"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@digitalbazaar/ed25519-verification-key-2018": "digitalbazaar/ed25519-verification-key-2018#cryptold-5",
     "chai": "^4.2.0",
+    "chai-bytes": "^0.1.2",
     "cross-env": "^7.0.2",
     "eslint": "^7.9.0",
     "eslint-config-digitalbazaar": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "esm": "^3.2.25"
   },
   "devDependencies": {
+    "@digitalbazaar/ed25519-verification-key-2018": "digitalbazaar/ed25519-verification-key-2018#cryptold-5",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
     "eslint": "^7.9.0",

--- a/package.json
+++ b/package.json
@@ -20,9 +20,8 @@
     "esm": "^3.2.25"
   },
   "devDependencies": {
-    "@digitalbazaar/ed25519-verification-key-2018": "digitalbazaar/ed25519-verification-key-2018#cryptold-5",
+    "@digitalbazaar/ed25519-verification-key-2018": "^3.0.0",
     "chai": "^4.2.0",
-    "chai-bytes": "^0.1.2",
     "cross-env": "^7.0.2",
     "eslint": "^7.9.0",
     "eslint-config-digitalbazaar": "^2.0.0",
@@ -57,7 +56,7 @@
     "test": "npm run lint && npm run test-node && npm run test-karma",
     "test-karma": "karma start karma.conf.js",
     "test-node": "cross-env NODE_ENV=test mocha -r esm --preserve-symlinks -t 10000 test/**/*.spec.js",
-    "lint": "eslint . --fix"
+    "lint": "eslint ."
   },
   "nyc": {
     "exclude": [

--- a/test/Ed25519VerificationKey2020.spec.js
+++ b/test/Ed25519VerificationKey2020.spec.js
@@ -2,13 +2,11 @@
  * Copyright (c) 2020 Digital Bazaar, Inc. All rights reserved.
  */
 import chai from 'chai';
-import deepEql from 'deep-eql';
 import * as base58btc from 'base58-universal';
 import {mockKey, seed} from './mock-data.js';
 import multibase from 'multibase';
 import multicodec from 'multicodec';
 const should = chai.should();
-chai.use(deepEql);
 const {expect} = chai;
 
 import {Ed25519VerificationKey2020} from '../';

--- a/test/Ed25519VerificationKey2020.spec.js
+++ b/test/Ed25519VerificationKey2020.spec.js
@@ -2,13 +2,13 @@
  * Copyright (c) 2020 Digital Bazaar, Inc. All rights reserved.
  */
 import chai from 'chai';
-import chaiBytes from 'chai-bytes';
+import deepEql from 'deep-eql';
 import * as base58btc from 'base58-universal';
 import {mockKey, seed} from './mock-data.js';
 import multibase from 'multibase';
 import multicodec from 'multicodec';
 const should = chai.should();
-chai.use(chaiBytes);
+chai.use(deepEql);
 const {expect} = chai;
 
 import {Ed25519VerificationKey2020} from '../';
@@ -249,7 +249,7 @@ describe('Ed25519VerificationKey2020', () => {
 
       const signatureBytes2020 = await keyPair2020.signer().sign({data});
 
-      expect(signatureBytes2018).to.equalBytes(signatureBytes2020);
+      expect(signatureBytes2018).to.eql(signatureBytes2020);
       expect(
         await keyPair2020.verifier()
           .verify({data, signature: signatureBytes2018})
@@ -267,7 +267,7 @@ describe('Ed25519VerificationKey2020', () => {
       const data = (new TextEncoder()).encode('test data goes here');
       const signatureBytes2018 = await keyPair2018.signer().sign({data});
       const signatureBytes2020 = await keyPair2020.signer().sign({data});
-      expect(signatureBytes2018).to.equalBytes(signatureBytes2020);
+      expect(signatureBytes2018).to.eql(signatureBytes2020);
     });
   });
 });

--- a/test/Ed25519VerificationKey2020.spec.js
+++ b/test/Ed25519VerificationKey2020.spec.js
@@ -70,8 +70,10 @@ describe('Ed25519VerificationKey2020', () => {
 
   describe('export', () => {
     it('should export id, type and key material', async () => {
+      // Encoding returns a 64 byte uint8array, seed needs to be 32 bytes
+      const seedBytes = (new TextEncoder()).encode(seed).slice(0, 32);
       const keyPair = await Ed25519VerificationKey2020.generate({
-        seed: Buffer.from(seed, 'hex'), controller: 'did:example:1234'
+        seed: seedBytes, controller: 'did:example:1234'
       });
       const exported = await keyPair.export({
         publicKey: true, privateKey: true
@@ -80,12 +82,12 @@ describe('Ed25519VerificationKey2020', () => {
       expect(exported.controller).to.equal('did:example:1234');
       expect(exported.type).to.equal('Ed25519VerificationKey2020');
       expect(exported.id).to.equal('did:example:1234#' +
-        'z6MkjLrk3gKS2nnkeWcmcxiZPGskmesDpuwRBorgHxUXfxnG');
+        'z6Mkpw72M9suPCBv48X2Xj4YKZJH9W7wzEK1aS6JioKSo89C');
       expect(exported).to.have.property('publicKeyMultibase',
-        'z5tbhTS4zhFJHY1n4wPkiYBKkx5bNR2h4VnwkTgWWkjzt');
+        'zBUqykudU3ehSwdgKrA6hUTkHKvr6aM4etRBNtXMRsuMp');
       expect(exported).to.have.property('privateKeyMultibase',
-        'z3oVh1q7ATzrYZ14sMS13rKynAqyyzeHSbv2UpaqY1LggKEc4Ji2a69jtJnM' +
-        'pGAzsFzY2NTUQymGK35XzgpywqcFv');
+        'z28PTidbitmCPf5tzHVLnAUNu1KuLXVvrnEKSgCZzjoRDWyh156tjJYN1uwptLjF' +
+        'CeHXaCNDmbjyzezLjMxaxD5Rg');
     });
   });
 
@@ -101,8 +103,10 @@ describe('Ed25519VerificationKey2020', () => {
 
   describe('static from', () => {
     it('should round-trip load exported keys', async () => {
+      // Encoding returns a 64 byte uint8array, seed needs to be 32 bytes
+      const seedBytes = (new TextEncoder()).encode(seed).slice(0, 32);
       const keyPair = await Ed25519VerificationKey2020.generate({
-        seed: Buffer.from(seed, 'hex'), controller: 'did:example:1234'
+        seed: seedBytes, controller: 'did:example:1234'
       });
       const exported = await keyPair.export({
         publicKey: true, privateKey: true

--- a/test/Ed25519VerificationKey2020.spec.js
+++ b/test/Ed25519VerificationKey2020.spec.js
@@ -2,14 +2,18 @@
  * Copyright (c) 2020 Digital Bazaar, Inc. All rights reserved.
  */
 import chai from 'chai';
+import chaiBytes from 'chai-bytes';
 import * as base58btc from 'base58-universal';
 import {mockKey, seed} from './mock-data.js';
 import multibase from 'multibase';
 import multicodec from 'multicodec';
 const should = chai.should();
+chai.use(chaiBytes);
 const {expect} = chai;
 
 import {Ed25519VerificationKey2020} from '../';
+import {Ed25519VerificationKey2018}
+  from '@digitalbazaar/ed25519-verification-key-2018';
 
 describe('Ed25519VerificationKey2020', () => {
   describe('constructor', () => {
@@ -222,6 +226,48 @@ describe('Ed25519VerificationKey2020', () => {
       result.valid.should.be.a('boolean');
       result.valid.should.be.true;
       fingerprint.should.equal(fingerprint2);
+    });
+  });
+
+  describe('Backwards compat with Ed25519VerificationKey2018', () => {
+    const seedBytes = (new TextEncoder()).encode(seed).slice(0, 32);
+
+    it('2020 key should import from 2018', async () => {
+      const keyPair2018 = await Ed25519VerificationKey2018.generate({
+        seed: seedBytes, controller: 'did:example:1234'
+      });
+
+      const keyPair2020 = await Ed25519VerificationKey2020
+        .fromEd25519VerificationKey2018({keyPair: keyPair2018});
+
+      // Both should have the same fingerprint
+      expect(keyPair2018.fingerprint()).to.equal(keyPair2020.fingerprint());
+
+      // Both should sign and verify the same
+      const data = (new TextEncoder()).encode('test data goes here');
+      const signatureBytes2018 = await keyPair2018.signer().sign({data});
+
+      const signatureBytes2020 = await keyPair2020.signer().sign({data});
+
+      expect(signatureBytes2018).to.equalBytes(signatureBytes2020);
+      expect(
+        await keyPair2020.verifier()
+          .verify({data, signature: signatureBytes2018})
+      ).to.be.true;
+    });
+
+    it('2020 key should generate the same from seed as 2018', async () => {
+      const keyPair2018 = await Ed25519VerificationKey2018.generate({
+        seed: seedBytes, controller: 'did:example:1234'
+      });
+      const keyPair2020 = await Ed25519VerificationKey2020.generate({
+        seed: seedBytes, controller: 'did:example:1234'
+      });
+
+      const data = (new TextEncoder()).encode('test data goes here');
+      const signatureBytes2018 = await keyPair2018.signer().sign({data});
+      const signatureBytes2020 = await keyPair2020.signer().sign({data});
+      expect(signatureBytes2018).to.equalBytes(signatureBytes2020);
     });
   });
 });


### PR DESCRIPTION
* Update to use `crypto-ld` dep v5. (See also similar PR https://github.com/digitalbazaar/ed25519-verification-key-2018/pull/13)
* Adds a backwards-compatibility conversion method, `Ed25519VerificationKey2020.fromEd25519VerificationKey2018()`, as well as backwards-compat tests and usage instructions for upgrading from 2018 in the README.