### PR TITLE
Ensure signer() and verifier() objects have id property.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @digitalbazaar/ed25519-verification-key-2020 ChangeLog
 
+## 2.1.1 -
+
+### Fixed
+- Ensure `signer()` and `verifier()` objects have an `id` property (for jsigs).
+
 ## 2.1.0 - 2021-04-01
 
 ### Added

--- a/lib/Ed25519VerificationKey2020.js
+++ b/lib/Ed25519VerificationKey2020.js
@@ -261,6 +261,7 @@ export class Ed25519VerificationKey2020 extends LDKeyPair {
       async sign({data}) {
         return ed25519.sign(privateKeyBuffer, data);
       },
+      id: this.id
     };
   }
 
@@ -271,6 +272,7 @@ export class Ed25519VerificationKey2020 extends LDKeyPair {
       async verify({data, signature}) {
         return ed25519.verify(publicKeyBuffer, data, signature);
       },
+      id: this.id
     };
   }
 }

--- a/test/sign-verify.spec.js
+++ b/test/sign-verify.spec.js
@@ -24,6 +24,10 @@ const targetSignatureBase58 = '57PG4Ahy97k8iwmRVf8bEK9ZXuy8Q7wz3Mx' +
 
 describe('sign and verify', () => {
   it('works properly', async () => {
+    signer.should.have.property('id',
+      'did:example:1234#z6MkszZtxCmA2Ce4vUV132PCuLQmwnaDD5mw2L23fGNnsiX3');
+    verifier.should.have.property('id',
+      'did:example:1234#z6MkszZtxCmA2Ce4vUV132PCuLQmwnaDD5mw2L23fGNnsiX3');
     const data = stringToUint8Array('test 1234');
     const signature = await signer.sign({data});
     base58btc.encode(signature).should.equal(targetSignatureBase58);


### PR DESCRIPTION
jsigs expects the signer object to have an `.id` property.