### PR TITLE
Implement JWK thumbprint, conversion to and from JWK.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @digitalbazaar/ed25519-verification-key-2020 ChangeLog
 
+## 3.2.0 - 
+
+### Added
+- Add support for `JsonWebKey2020` and JWK import/export, as well as
+  JWK thumbprint function.
+
 ## 3.1.0 - 2021-06-24
 
 ### Changed

--- a/lib/Ed25519VerificationKey2020.js
+++ b/lib/Ed25519VerificationKey2020.js
@@ -314,6 +314,7 @@ export class Ed25519VerificationKey2020 extends LDKeyPair {
    */
   async toJsonWebKey2020() {
     return {
+      '@context': 'https://w3id.org/security/jws/v1',
       id: this.controller + '#' + await this.jwkThumbprint(),
       type: 'JsonWebKey2020',
       controller: this.controller,

--- a/lib/Ed25519VerificationKey2020.js
+++ b/lib/Ed25519VerificationKey2020.js
@@ -148,7 +148,8 @@ export class Ed25519VerificationKey2020 extends LDKeyPair {
       throw new TypeError('"crv" is required to be "Ed25519".');
     }
     const {x: publicKeyBase64Url} = publicKeyJwk;
-    const publicKeyMultibase = _encodeMbKey(MULTICODEC_ED25519_PUB_HEADER,
+    const publicKeyMultibase = _encodeMbKey(
+      MULTICODEC_ED25519_PUB_HEADER,
       base64url.decode(publicKeyBase64Url));
 
     return Ed25519VerificationKey2020.from({

--- a/lib/Ed25519VerificationKey2020.js
+++ b/lib/Ed25519VerificationKey2020.js
@@ -127,12 +127,26 @@ export class Ed25519VerificationKey2020 extends LDKeyPair {
    *
    * @param {object} options - Options hashmap.
    * @param {string} options.id - Key id.
-   * @param {string} options.controller - Key controler.
+   * @param {string} options.type - Key suite type.
+   * @param {string} options.controller - Key controller.
    * @param {object} options.publicKeyJwk - JWK object.
    *
    * @returns {Promise<Ed25519VerificationKey2020>} Resolves with key pair.
    */
-  static fromJsonWebKey2020({id, controller, publicKeyJwk} = {}) {
+  static fromJsonWebKey2020({id, type, controller, publicKeyJwk} = {}) {
+    if(type !== 'JsonWebKey2020') {
+      throw new TypeError(`Invalid key type: "${type}".`);
+    }
+    if(!publicKeyJwk) {
+      throw new TypeError('"publicKeyJwk" property is required.');
+    }
+    const {kty, crv} = publicKeyJwk;
+    if(kty !== 'OKP') {
+      throw new TypeError('"kty" is required to be "OKP".');
+    }
+    if(crv !== 'Ed25519') {
+      throw new TypeError('"crv" is required to be "Ed25519".');
+    }
     const {x: publicKeyBase64Url} = publicKeyJwk;
     const publicKeyMultibase = _encodeMbKey(MULTICODEC_ED25519_PUB_HEADER,
       base64url.decode(publicKeyBase64Url));

--- a/lib/Ed25519VerificationKey2020.js
+++ b/lib/Ed25519VerificationKey2020.js
@@ -120,6 +120,29 @@ export class Ed25519VerificationKey2020 extends LDKeyPair {
   }
 
   /**
+   * Creates a key pair instance (public key only) from a JsonWebKey2020
+   * object.
+   *
+   * @see https://w3c-ccg.github.io/lds-jws2020/#json-web-key-2020
+   *
+   * @param {object} options - Options hashmap.
+   * @param {string} options.id - Key id.
+   * @param {string} options.controller - Key controler.
+   * @param {object} options.publicKeyJwk - JWK object.
+   *
+   * @returns {Promise<Ed25519VerificationKey2020>} Resolves with key pair.
+   */
+  static fromJsonWebKey2020({id, controller, publicKeyJwk} = {}) {
+    const {x: publicKeyBase64Url} = publicKeyJwk;
+    const publicKeyMultibase = _encodeMbKey(MULTICODEC_ED25519_PUB_HEADER,
+      base64url.decode(publicKeyBase64Url));
+
+    return Ed25519VerificationKey2020.from({
+      id, controller, publicKeyMultibase
+    });
+  }
+
+  /**
    * Generates a KeyPair with an optional deterministic seed.
    *
    * @param {object} [options={}] - Options hashmap.
@@ -296,16 +319,6 @@ export class Ed25519VerificationKey2020 extends LDKeyPair {
       controller: this.controller,
       publicKeyJwk: this.toJwk({publicKey: true})
     };
-  }
-
-  static fromJsonWebKey2020({id, controller, publicKeyJwk} = {}) {
-    const {x: publicKeyBase64Url} = publicKeyJwk;
-    const publicKeyMultibase = _encodeMbKey(MULTICODEC_ED25519_PUB_HEADER,
-      base64url.decode(publicKeyBase64Url));
-
-    return Ed25519VerificationKey2020.from({
-      id, controller, publicKeyMultibase
-    });
   }
 
   /**

--- a/lib/Ed25519VerificationKey2020.js
+++ b/lib/Ed25519VerificationKey2020.js
@@ -2,6 +2,7 @@
  * Copyright (c) 2021 Digital Bazaar, Inc. All rights reserved.
  */
 import * as base58btc from 'base58-universal';
+import * as base64url from 'base64url-universal';
 import ed25519 from './ed25519.js';
 import {LDKeyPair} from 'crypto-ld';
 
@@ -81,6 +82,12 @@ export class Ed25519VerificationKey2020 extends LDKeyPair {
    * @returns {Promise<Ed25519VerificationKey2020>} An Ed25519 Key Pair.
    */
   static async from(options) {
+    if(options.type === 'Ed25519VerificationKey2018') {
+      return Ed25519VerificationKey2020.fromEd25519VerificationKey2018(options);
+    }
+    if(options.type === 'JsonWebKey2020') {
+      return Ed25519VerificationKey2020.fromJsonWebKey2020(options);
+    }
     return new Ed25519VerificationKey2020(options);
   }
 
@@ -155,6 +162,9 @@ export class Ed25519VerificationKey2020 extends LDKeyPair {
     return new Ed25519VerificationKey2020({publicKeyMultibase: fingerprint});
   }
 
+  /**
+   * @returns {Uint8Array} Public key bytes.
+   */
   get _publicKeyBuffer() {
     if(!this.publicKeyMultibase) {
       return;
@@ -169,6 +179,9 @@ export class Ed25519VerificationKey2020 extends LDKeyPair {
     return publicKeyBytes;
   }
 
+  /**
+   * @returns {Uint8Array} Private key bytes.
+   */
   get _privateKeyBuffer() {
     if(!this.privateKeyMultibase) {
       return;
@@ -232,6 +245,67 @@ export class Ed25519VerificationKey2020 extends LDKeyPair {
       exportedKey.revoked = this.revoked;
     }
     return exportedKey;
+  }
+
+  /**
+   * Returns the JWK representation of this key pair.
+   *
+   * @see https://datatracker.ietf.org/doc/html/rfc8037
+   *
+   * @param {object} [options={}] - Options hashmap.
+   * @param {boolean} [options.publicKey] - Include public key?
+   * @param {boolean} [options.privateKey] - Include private key?
+   *
+   * @returns {{kty: string, crv: string, x: string, d: string}} JWK
+   *   representation.
+   */
+  toJwk({publicKey = false, privateKey = false} = {}) {
+    const jwk = {crv: 'Ed25519', kty: 'OKP'};
+    if(publicKey) {
+      jwk.x = base64url.encode(this._publicKeyBuffer);
+    }
+    if(privateKey) {
+      jwk.d = base64url.encode(this._privateKeyBuffer);
+    }
+    return jwk;
+  }
+
+  /**
+   * @see https://datatracker.ietf.org/doc/html/rfc8037#appendix-A.3
+   *
+   * @returns {Promise<string>} JWK Thumbprint.
+   */
+  async jwkThumbprint() {
+    const serialized = JSON.stringify(this.toJwk({publicKey: true}));
+    const data = new TextEncoder().encode(serialized);
+    return base64url.encode(
+      new Uint8Array(await ed25519.sha256digest({data})));
+  }
+
+  /**
+   * Returns the JsonWebKey2020 representation of this key pair.
+   *
+   * @see https://w3c-ccg.github.io/lds-jws2020/#json-web-key-2020
+   *
+   * @returns {Promise<object>} JsonWebKey2020 representation.
+   */
+  async toJsonWebKey2020() {
+    return {
+      id: this.controller + '#' + await this.jwkThumbprint(),
+      type: 'JsonWebKey2020',
+      controller: this.controller,
+      publicKeyJwk: this.toJwk({publicKey: true})
+    };
+  }
+
+  static fromJsonWebKey2020({id, controller, publicKeyJwk} = {}) {
+    const {x: publicKeyBase64Url} = publicKeyJwk;
+    const publicKeyMultibase = _encodeMbKey(MULTICODEC_ED25519_PUB_HEADER,
+      base64url.decode(publicKeyBase64Url));
+
+    return Ed25519VerificationKey2020.from({
+      id, controller, publicKeyMultibase
+    });
   }
 
   /**

--- a/lib/Ed25519VerificationKey2020.js
+++ b/lib/Ed25519VerificationKey2020.js
@@ -297,7 +297,10 @@ export class Ed25519VerificationKey2020 extends LDKeyPair {
    * @returns {{kty: string, crv: string, x: string, d: string}} JWK
    *   representation.
    */
-  toJwk({publicKey = false, privateKey = false} = {}) {
+  toJwk({publicKey = true, privateKey = false} = {}) {
+    if(!(publicKey || privateKey)) {
+      throw TypeError('Either a "publicKey" or a "privateKey" is required.');
+    }
     const jwk = {crv: 'Ed25519', kty: 'OKP'};
     if(publicKey) {
       jwk.x = base64url.encode(this._publicKeyBuffer);

--- a/lib/Ed25519VerificationKey2020.js
+++ b/lib/Ed25519VerificationKey2020.js
@@ -313,7 +313,8 @@ export class Ed25519VerificationKey2020 extends LDKeyPair {
    * @returns {Promise<string>} JWK Thumbprint.
    */
   async jwkThumbprint() {
-    const serialized = JSON.stringify(this.toJwk({publicKey: true}));
+    const publicKey = base64url.encode(this._publicKeyBuffer);
+    const serialized = `{"crv":"Ed25519","kty":"OKP","x":"${publicKey}"}`;
     const data = new TextEncoder().encode(serialized);
     return base64url.encode(
       new Uint8Array(await ed25519.sha256digest({data})));

--- a/lib/ed25519-browser.js
+++ b/lib/ed25519-browser.js
@@ -15,5 +15,8 @@ export default {
     const seed = new Uint8Array(32);
     crypto.getRandomValues(seed);
     return ed25519.generateKeyPairFromSeed(seed);
+  },
+  async sha256digest({data}) {
+    return crypto.subtle.digest('SHA-256', data);
   }
 };

--- a/lib/ed25519.js
+++ b/lib/ed25519.js
@@ -4,6 +4,7 @@
 import {
   sign,
   verify,
+  createHash,
   createPrivateKey,
   createPublicKey,
   randomBytes
@@ -65,6 +66,9 @@ const api = {
       type: 'spki'
     });
     return verify(null, data, publicKey, signature);
+  },
+  async sha256digest({data}) {
+    return createHash('sha256').update(data).digest();
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@stablelib/ed25519": "^1.0.1",
     "base58-universal": "^1.0.0",
+    "base64url-universal": "^1.1.0",
     "crypto-ld": "^5.1.0",
     "esm": "^3.2.25"
   },

--- a/test/Ed25519VerificationKey2020.spec.js
+++ b/test/Ed25519VerificationKey2020.spec.js
@@ -302,4 +302,49 @@ describe('Ed25519VerificationKey2020', () => {
       expect(signatureBytes2018).to.eql(signatureBytes2020);
     });
   });
+
+  describe('JsonWebKey2020', () => {
+    it('round trip imports/exports', async () => {
+      const keyData = {
+        id: 'did:example:123#kPrK_qmxVWaYVA9wwBF6Iuo3vVzz7TxHCTwXBygrS4k',
+        type: 'JsonWebKey2020',
+        controller: 'did:example:123',
+        publicKeyJwk: {
+          kty: 'OKP',
+          crv: 'Ed25519',
+          x: '11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo'
+        }
+      };
+
+      const key = await Ed25519VerificationKey2020.from(keyData);
+
+      expect(key.controller).to.equal('did:example:123');
+      expect(key.id).to
+        .equal('did:example:123#kPrK_qmxVWaYVA9wwBF6Iuo3vVzz7TxHCTwXBygrS4k');
+      expect(key.publicKeyMultibase).to
+        .equal('z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw');
+
+      const exported = await key.toJsonWebKey2020();
+
+      expect(exported).to.eql(keyData);
+    });
+
+    it('computes jwk thumbprint', async () => {
+      const keyData = {
+        id: 'did:example:123#_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A',
+        type: 'JsonWebKey2020',
+        controller: 'did:example:123',
+        publicKeyJwk: {
+          kty: 'OKP',
+          crv: 'Ed25519',
+          x: 'VCpo2LMLhn6iWku8MKvSLg2ZAoC-nlOyPVQaO3FxVeQ'
+        }
+      };
+
+      const key = await Ed25519VerificationKey2020.from(keyData);
+
+      expect(await key.jwkThumbprint()).to
+        .equal('_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A');
+    });
+  });
 });

--- a/test/Ed25519VerificationKey2020.spec.js
+++ b/test/Ed25519VerificationKey2020.spec.js
@@ -306,6 +306,7 @@ describe('Ed25519VerificationKey2020', () => {
   describe('JsonWebKey2020', () => {
     it('round trip imports/exports', async () => {
       const keyData = {
+        '@context': 'https://w3id.org/security/jws/v1',
         id: 'did:example:123#kPrK_qmxVWaYVA9wwBF6Iuo3vVzz7TxHCTwXBygrS4k',
         type: 'JsonWebKey2020',
         controller: 'did:example:123',


### PR DESCRIPTION
Adds compatibility with CCG's [JsonWebKey2020](https://w3c-ccg.github.io/lds-jws2020/#json-web-key-2020) spec and [RFC8037](https://datatracker.ietf.org/doc/html/rfc8037)