### PR TITLE
Add did key error codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Added a new validators file with `assertKeyBytes.`
 - Public key byte checks have error codes compatible with the `did:key` spec.
 
-## Changed
+### Changed
 - Previous key bytes checks are now all done with `checkKeyBytes`.
 
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @digitalbazaar/ed25519-verification-key-2020 ChangeLog
 
+## 4.1.0 - 
+
+### Added
+- Added a new validators file with `checkKeyBytes.`
+- Public key byte checks have error codes compatible with the `did:key` spec.
+
+## Changed
+- Previous key bytes checks are now all done with `checkKeyBytes`.
+
+## Fixed
+- No longer throw a `TypeError` when passing in a Uint8Array of the wrong length.
+
 ## 4.0.0 - 2022-06-02
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Changed
 - Previous key bytes checks are now all done with `checkKeyBytes`.
 
-## Fixed
+### Fixed
 - No longer throw a `TypeError` when passing in a Uint8Array of the wrong length.
 
 ## 4.0.0 - 2022-06-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 4.1.0 - 
 
 ### Added
-- Added a new validators file with `checkKeyBytes.`
+- Added a new validators file with `assertKeyBytes.`
 - Public key byte checks have error codes compatible with the `did:key` spec.
 
 ## Changed

--- a/lib/Ed25519VerificationKey2020.js
+++ b/lib/Ed25519VerificationKey2020.js
@@ -65,7 +65,7 @@ export class Ed25519VerificationKey2020 extends LDKeyPair {
     if(this.controller && !this.id) {
       this.id = `${this.controller}#${this.fingerprint()}`;
     }
-    if(!this._publicKeyBuffer.length === 32) {
+    if(!(this._publicKeyBuffer.length === 32)) {
       const error = new SyntaxError(
         '`publicKeyBytes` must be a 32 byte Buffer.');
       // add the error code from the did:key spec

--- a/lib/Ed25519VerificationKey2020.js
+++ b/lib/Ed25519VerificationKey2020.js
@@ -3,7 +3,7 @@
  */
 import * as base58btc from 'base58-universal';
 import * as base64url from 'base64url-universal';
-import {checkKeyBytes} from './validators.js';
+import {assertKeyBytes} from './validators.js';
 import ed25519 from './ed25519.js';
 import {LDKeyPair} from 'crypto-ld';
 
@@ -67,7 +67,7 @@ export class Ed25519VerificationKey2020 extends LDKeyPair {
       this.id = `${this.controller}#${this.fingerprint()}`;
     }
     // check that the passed in keyBytes are 32 bytes
-    checkKeyBytes({
+    assertKeyBytes({
       bytes: this._publicKeyBuffer,
       code: 'invalidPublicKeyLength',
       expectedLength: 32

--- a/lib/Ed25519VerificationKey2020.js
+++ b/lib/Ed25519VerificationKey2020.js
@@ -65,6 +65,13 @@ export class Ed25519VerificationKey2020 extends LDKeyPair {
     if(this.controller && !this.id) {
       this.id = `${this.controller}#${this.fingerprint()}`;
     }
+    if(!this._publicKeyBuffer.length === 32) {
+      const error = new SyntaxError(
+        '`publicKeyBytes` must be a 32 byte Buffer.');
+      // add the error code from the did:key spec
+      error.code = 'invalidPublicKeyLength';
+      throw error;
+    }
   }
 
   /**

--- a/lib/Ed25519VerificationKey2020.js
+++ b/lib/Ed25519VerificationKey2020.js
@@ -3,6 +3,7 @@
  */
 import * as base58btc from 'base58-universal';
 import * as base64url from 'base64url-universal';
+import {checkKeyBytes} from './validators.js';
 import ed25519 from './ed25519.js';
 import {LDKeyPair} from 'crypto-ld';
 
@@ -65,13 +66,12 @@ export class Ed25519VerificationKey2020 extends LDKeyPair {
     if(this.controller && !this.id) {
       this.id = `${this.controller}#${this.fingerprint()}`;
     }
-    if(!(this._publicKeyBuffer.length === 32)) {
-      const error = new SyntaxError(
-        '`publicKeyBytes` must be a 32 byte Buffer.');
-      // add the error code from the did:key spec
-      error.code = 'invalidPublicKeyLength';
-      throw error;
-    }
+    // check that the passed in keyBytes are 32 bytes
+    checkKeyBytes({
+      bytes: this._publicKeyBuffer,
+      code: 'invalidPublicKeyLength',
+      expectedLength: 32
+    });
   }
 
   /**

--- a/lib/ed25519-browser.js
+++ b/lib/ed25519-browser.js
@@ -1,6 +1,7 @@
 /*!
  * Copyright (c) 2020-2022 Digital Bazaar, Inc. All rights reserved.
  */
+import {checkKeyBytes} from './validators.js';
 import * as ed25519 from '@noble/ed25519';
 
 // browser MUST provide "crypto.getRandomValues"
@@ -30,6 +31,10 @@ export default {
 };
 
 async function generateKeyPairFromSeed(seed) {
+  checkKeyBytes({
+    bytes: seed,
+    expectedLength: 32,
+  });
   const publicKey = await ed25519.getPublicKey(seed);
   const secretKey = new Uint8Array(64);
   secretKey.set(seed);

--- a/lib/ed25519-browser.js
+++ b/lib/ed25519-browser.js
@@ -1,7 +1,7 @@
 /*!
  * Copyright (c) 2020-2022 Digital Bazaar, Inc. All rights reserved.
  */
-import {checkKeyBytes} from './validators.js';
+import {assertKeyBytes} from './validators.js';
 import * as ed25519 from '@noble/ed25519';
 
 // browser MUST provide "crypto.getRandomValues"
@@ -31,7 +31,7 @@ export default {
 };
 
 async function generateKeyPairFromSeed(seed) {
-  checkKeyBytes({
+  assertKeyBytes({
     bytes: seed,
     expectedLength: 32,
   });

--- a/lib/ed25519.js
+++ b/lib/ed25519.js
@@ -9,7 +9,7 @@ import {
   createPublicKey,
   randomBytes
 } from 'node:crypto';
-
+import {checkKeyBytes} from './validators.js';
 import {promisify} from 'node:util';
 
 const randomBytesAsync = promisify(randomBytes);
@@ -111,13 +111,17 @@ function privateKeyDerEncode({privateKeyBytes, seedBytes}) {
   if(!(privateKeyBytes || seedBytes)) {
     throw new TypeError('`privateKeyBytes` or `seedBytes` is required.');
   }
-  if(!privateKeyBytes && !(seedBytes instanceof Uint8Array &&
-    seedBytes.length === 32)) {
-    throw new TypeError('`seedBytes` must be a 32 byte Buffer.');
+  if(!privateKeyBytes) {
+    checkKeyBytes({
+      bytes: seedBytes,
+      expectedLength: 32
+    });
   }
-  if(!seedBytes && !(privateKeyBytes instanceof Uint8Array &&
-    privateKeyBytes.length === 64)) {
-    throw new TypeError('`privateKeyBytes` must be a 64 byte Buffer.');
+  if(!seedBytes) {
+    checkKeyBytes({
+      bytes: privateKeyBytes,
+      expectedLength: 64
+    });
   }
   let p;
   if(seedBytes) {
@@ -142,11 +146,10 @@ function privateKeyDerEncode({privateKeyBytes, seedBytes}) {
  * @returns {Buffer} DER Public key Prefix + key bytes.
 */
 function publicKeyDerEncode({publicKeyBytes}) {
-  if(!(publicKeyBytes instanceof Uint8Array && publicKeyBytes.length === 32)) {
-    const error = new SyntaxError('`publicKeyBytes` must be a 32 byte Buffer.');
-    // add the error code from the did:key spec
-    error.code = 'invalidPublicKeyLength';
-    throw error;
-  }
+  checkKeyBytes({
+    bytes: publicKeyBytes,
+    expectedLength: 32,
+    code: 'invalidPublicKeyLength'
+  });
   return Buffer.concat([DER_PUBLIC_KEY_PREFIX, publicKeyBytes]);
 }

--- a/lib/ed25519.js
+++ b/lib/ed25519.js
@@ -143,10 +143,10 @@ function privateKeyDerEncode({privateKeyBytes, seedBytes}) {
 */
 function publicKeyDerEncode({publicKeyBytes}) {
   if(!(publicKeyBytes instanceof Uint8Array && publicKeyBytes.length === 32)) {
-    throw new TypeError(
-      '`publicKeyBytes` must be a 32 byte Buffer.',
-      {cause: 'invalidPublicKeyLength'}
-    );
+    const error = new SyntaxError('`publicKeyBytes` must be a 32 byte Buffer.');
+    // add the error code from the did:key spec
+    error.code = 'invalidPublicKeyLength';
+    throw error;
   }
   return Buffer.concat([DER_PUBLIC_KEY_PREFIX, publicKeyBytes]);
 }

--- a/lib/ed25519.js
+++ b/lib/ed25519.js
@@ -9,7 +9,7 @@ import {
   createPublicKey,
   randomBytes
 } from 'node:crypto';
-import {checkKeyBytes} from './validators.js';
+import {assertKeyBytes} from './validators.js';
 import {promisify} from 'node:util';
 
 const randomBytesAsync = promisify(randomBytes);
@@ -112,13 +112,13 @@ function privateKeyDerEncode({privateKeyBytes, seedBytes}) {
     throw new TypeError('`privateKeyBytes` or `seedBytes` is required.');
   }
   if(!privateKeyBytes) {
-    checkKeyBytes({
+    assertKeyBytes({
       bytes: seedBytes,
       expectedLength: 32
     });
   }
   if(!seedBytes) {
-    checkKeyBytes({
+    assertKeyBytes({
       bytes: privateKeyBytes,
       expectedLength: 64
     });
@@ -146,7 +146,7 @@ function privateKeyDerEncode({privateKeyBytes, seedBytes}) {
  * @returns {Buffer} DER Public key Prefix + key bytes.
 */
 function publicKeyDerEncode({publicKeyBytes}) {
-  checkKeyBytes({
+  assertKeyBytes({
     bytes: publicKeyBytes,
     expectedLength: 32,
     code: 'invalidPublicKeyLength'

--- a/lib/ed25519.js
+++ b/lib/ed25519.js
@@ -143,7 +143,10 @@ function privateKeyDerEncode({privateKeyBytes, seedBytes}) {
 */
 function publicKeyDerEncode({publicKeyBytes}) {
   if(!(publicKeyBytes instanceof Uint8Array && publicKeyBytes.length === 32)) {
-    throw new TypeError('`publicKeyBytes` must be a 32 byte Buffer.');
+    throw new TypeError(
+      '`publicKeyBytes` must be a 32 byte Buffer.',
+      {cause: 'invalidPublicKeyLength'}
+    );
   }
   return Buffer.concat([DER_PUBLIC_KEY_PREFIX, publicKeyBytes]);
 }

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -14,7 +14,7 @@
  *
  * @returns {undefined} Returns on success throws on error.
  */
-export const checkKeyBytes = ({bytes, expectedLength = 32, code}) => {
+export function assertKeyBytes({bytes, expectedLength = 32, code}) {
   if(!(bytes instanceof Uint8Array)) {
     throw new TypeError('"bytes" must be a Uint8Array.');
   }

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -1,0 +1,26 @@
+/**
+ * Checks that key bytes have a type of Uint8Array and a specific length.
+ *
+ * @throws {TypeError|SyntaxError} - Throws a Type or Syntax error.
+ *
+ * @param {object} options - Options to use.
+ * @param {Uint8Array} options.bytes - The bytes being checked.
+ * @param {number} [options.expectedLength=32] - The expected bytes length.
+ * @param {string} [options.code] - An optional code for the error.
+ *
+ * @returns {undefined} Returns on success throws on error.
+ */
+export const checkKeyBytes = ({bytes, expectedLength = 32, code}) => {
+  if(!(bytes instanceof Uint8Array)) {
+    throw new TypeError('Expected bytes to be an Uint8Array');
+  }
+  if(!(bytes.length === expectedLength)) {
+    const error = new SyntaxError(
+      `\`bytes\` must be a ${expectedLength} byte Uint8Array.`);
+    // add the error code from the did:key spec
+    if(code) {
+      error.code = code;
+    }
+    throw error;
+  }
+};

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -1,3 +1,7 @@
+/*!
+ * Copyright (c) 2022 Digital Bazaar, Inc. All rights reserved.
+ */
+
 /**
  * Checks that key bytes have a type of Uint8Array and a specific length.
  *
@@ -17,7 +21,7 @@ export const checkKeyBytes = ({bytes, expectedLength = 32, code}) => {
   if(!(bytes.length === expectedLength)) {
     const error = new SyntaxError(
       `\`bytes\` must be a ${expectedLength} byte Uint8Array.`);
-    // add the error code from the did:key spec
+    // add the error code from the did:key spec if provided
     if(code) {
       error.code = code;
     }

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -23,7 +23,6 @@ export function assertKeyBytes({bytes, expectedLength = 32, code}) {
       `"bytes" must be a ${expectedLength}-byte Uint8Array.`);
     // we need DataError for invalid byte length
     error.name = 'DataError';
-    error.name = 'DataError';
     // add the error code from the did:key spec if provided
     if(code) {
       error.code = code;

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -16,7 +16,7 @@
  */
 export const checkKeyBytes = ({bytes, expectedLength = 32, code}) => {
   if(!(bytes instanceof Uint8Array)) {
-    throw new TypeError('Expected bytes to be an Uint8Array');
+    throw new TypeError('"bytes" must be a Uint8Array.');
   }
   if(!(bytes.length === expectedLength)) {
     const error = new SyntaxError(

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -3,7 +3,7 @@
  */
 
 /**
- * Checks that key bytes have a type of Uint8Array and a specific length.
+ * Asserts that key bytes have a type of Uint8Array and a specific length.
  *
  * @throws {TypeError|SyntaxError} - Throws a Type or Syntax error.
  *

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -18,7 +18,7 @@ export const checkKeyBytes = ({bytes, expectedLength = 32, code}) => {
   if(!(bytes instanceof Uint8Array)) {
     throw new TypeError('"bytes" must be a Uint8Array.');
   }
-  if(!(bytes.length === expectedLength)) {
+  if(bytes.length !== expectedLength) {
     const error = new SyntaxError(
       `\`bytes\` must be a ${expectedLength} byte Uint8Array.`);
     // we need DataError for invalid byte length

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -19,7 +19,7 @@ export const checkKeyBytes = ({bytes, expectedLength = 32, code}) => {
     throw new TypeError('"bytes" must be a Uint8Array.');
   }
   if(bytes.length !== expectedLength) {
-    const error = new SyntaxError(
+    const error = new Error(
       `"bytes" must be a ${expectedLength}-byte Uint8Array.`);
     // we need DataError for invalid byte length
     error.name = 'DataError';

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -21,6 +21,8 @@ export const checkKeyBytes = ({bytes, expectedLength = 32, code}) => {
   if(!(bytes.length === expectedLength)) {
     const error = new SyntaxError(
       `\`bytes\` must be a ${expectedLength} byte Uint8Array.`);
+    // we need DataError for invalid byte length
+    error.name = 'DataError';
     // add the error code from the did:key spec if provided
     if(code) {
       error.code = code;

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -23,6 +23,7 @@ export const checkKeyBytes = ({bytes, expectedLength = 32, code}) => {
       `"bytes" must be a ${expectedLength}-byte Uint8Array.`);
     // we need DataError for invalid byte length
     error.name = 'DataError';
+    error.name = 'DataError';
     // add the error code from the did:key spec if provided
     if(code) {
       error.code = code;

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -20,7 +20,7 @@ export const checkKeyBytes = ({bytes, expectedLength = 32, code}) => {
   }
   if(bytes.length !== expectedLength) {
     const error = new SyntaxError(
-      `\`bytes\` must be a ${expectedLength} byte Uint8Array.`);
+      `"bytes" must be a ${expectedLength}-byte Uint8Array.`);
     // we need DataError for invalid byte length
     error.name = 'DataError';
     // add the error code from the did:key spec if provided

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -30,4 +30,4 @@ export function assertKeyBytes({bytes, expectedLength = 32, code}) {
     }
     throw error;
   }
-};
+}


### PR DESCRIPTION
- Adds a new file `./lib/validators.js`
- Adds a new validator `checkKeyBytes.
- Separates `TypeError` from `SyntaxError`
- DRYs up key bytes checks
- Add error code for `invalidPublicKeyLength` to public key checks.

https://github.com/digitalbazaar/ed25519-verification-key-2020/issues/18