### PR TITLE
Correct checkKeyBytes to assertKeyBytes in Changed section of CHANGELOG.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Public key byte checks have error codes compatible with the `did:key` spec.
 
 ### Changed
-- Previous key bytes checks are now all done with `checkKeyBytes`.
+- Previous key bytes checks are now all done with `assertKeyBytes`.
 
 ### Fixed
 - No longer throw a `TypeError` when passing in a Uint8Array of the wrong length.


### PR DESCRIPTION
Sorry about this I missed one naming change in the CHANGELOG.